### PR TITLE
Fix breadcrumbs

### DIFF
--- a/stanzas/breadcrumbs/README.md
+++ b/stanzas/breadcrumbs/README.md
@@ -44,9 +44,7 @@ Than could be done by using
 
 ```html
 <togostanza--data-source
-  url="{url"
-  to
-  data}
+  url="<url to data>"
   receiver="name_of_first_stanza, name_of_second_stanza"
   target-attribute="data-url"
 ></togostanza--data-source>
@@ -59,5 +57,7 @@ To change currently showing hierarchy node, Breadcrumbs stanza need to receive e
 ```
 
 as event payload.
+
+Initially showing path could be defined by passing `initial-data-id` parameter, referring to id of the node, path to which should be shown at first loading.
 
 Also, when clicking on the node inside the Breadcrumbs stanza, will dispatch same `selectedDatumChanged` event with payload containing the `id` of clicked node in same manner.

--- a/stanzas/breadcrumbs/index.js
+++ b/stanzas/breadcrumbs/index.js
@@ -24,6 +24,7 @@ export default class Breadcrumbs extends Stanza {
 
   handleEvent(event) {
     event.stopPropagation();
+
     if (event.target !== this.element) {
       currentDataId = event.detail.id;
       this.render();
@@ -46,7 +47,7 @@ export default class Breadcrumbs extends Stanza {
       this.params["data-type"]
     );
 
-    if (!currentDataId) {
+    if (!currentDataId && this.props["initinal-data-id"]) {
       currentDataId = this.params["initinal-data-id"];
     }
 
@@ -160,15 +161,11 @@ function renderElement(el, data, opts, dispatcher = null) {
     contextMenu.style("display", "none");
   });
 
-  console.log(nestedData);
-
   const hierarchyData = d3.hierarchy(nestedData);
 
   const getCurrentData = (id) => {
-    console.log(typeof id);
     return hierarchyData
       .find((item) => {
-        console.log(typeof item.data.data.id);
         return item.data.data.id === id;
       })
       .ancestors()
@@ -305,6 +302,10 @@ function renderElement(el, data, opts, dispatcher = null) {
       .filter((d) => d.depth > 0)
       .selectAll("div.node-label")
       .text((d) => d.data.data.label);
+  }
+
+  if (!currentDataId) {
+    currentDataId = hierarchyData.find((data) => data.depth === 0).data.data.id;
   }
 
   update(getCurrentData(currentDataId));

--- a/stanzas/breadcrumbs/metadata.json
+++ b/stanzas/breadcrumbs/metadata.json
@@ -31,9 +31,8 @@
     {
       "stanza:key": "initinal-data-id",
       "stanza:type": "number",
-      "stanza:example": 6,
       "stanza:description": "Initial node id",
-      "stanza:required": true
+      "stanza:required": false
     },
     {
       "stanza:key": "custom-css-url",


### PR DESCRIPTION
1. 最初の表示されるデータidが `undefined`　だったバグを修正しました。(連携の時に)
2. Readme.md の修正